### PR TITLE
Fix vereadores

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 
 * ruby 2.1.9
 * rails 3.2.22.5
+* postgresql with additional modules installed (install postgres-contrib on Ubuntu Linux)
+
+From the psql command, run
+
+> CREATE EXTENSION unaccent;
 
 ## Minimal Setup
 Create a database config file at config/database.yml; you may use the config/database.sample.yml file as a starting point.
@@ -16,12 +21,16 @@ Use the bundle to install all the dependencies, as showed in example bellow:
 
 > bundle install
 
+In order to create the database structure, run
+
+> rake db:migrate
+
 To configure the facebook params, you must config this variables:
 - FB_ID: Your Facebook app ID 
 - FB_SECRET: Your App sercret key
 Please refer to https://developers.facebook.com/ for more information about them.
 
-In ubuntu linux you may configure them in your .bashrc file, located at your user's home dir as showed below:
+In Ubuntu Linux you may configure them in your .bashrc file, located at your user's home dir as showed below:
 > export FB_ID="12312312312"
 
 > export FB_SECRET="SASDSEWEWEWFA"

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -1,7 +1,7 @@
 class Candidate < ActiveRecord::Base
   attr_accessible :born_at, :male, :name, :nickname, :number, :party_id, :party, :email, :mobile_phone, :bio, :finished_at, :group_id, :short_url, :politician, :occupation, :scholarity, :city_id, :cpf, :electoral_title
 
-  validates :nickname, :email, :number, :party_id, :cpf, :born_at, :city_id, :presence => true
+  validates :nickname, :email, :party_id, :cpf, :born_at, :city_id, :presence => true
   validate :verify_tse_data
 
   belongs_to :party

--- a/app/views/candidates/edit.html.erb
+++ b/app/views/candidates/edit.html.erb
@@ -55,7 +55,8 @@
                 </div>
                 <% end %>
                 <div class="form-group row">
-                    <%= f.label :nickname, "Nome de urna *",  {class: "col-md-2 control-label"} %>
+			<span style="padding-left:15px;">(Nome pelo qual é conhecida/o, como seu nome de urna na última eleição)</span>
+                    <%= f.label :nickname, "Apelido *",  {class: "col-md-2 control-label"} %>
                     <div class="col-md-10">
                         <%= f.text_field :nickname, {class: "form-control"} %>
                     </div>
@@ -129,21 +130,6 @@
                     </div>
                 </div>
 
-                <% if @candidate.errors[:number].count > 0 %>
-                <div class="alert alert-danger" role="alert">
-                    <ul class="erros">
-                        <% @candidate.errors[:number].each do |msg| %>
-                        <li class="erro"><%= msg %></li>
-                        <% end %>
-                    </ul>
-                </div>
-                <% end %>
-                <div class="form-group row">
-                    <%= f.label :number, "Número de urna na eleição de 2016*",  {class: "col-md-2 control-label"} %>
-                    <div class="col-md-10">
-                        <%= f.text_field :number, {class: "form-control"} %>
-                    </div>
-                </div>
 
                 <% if @candidate.errors[:city_id].count > 0 %>
                 <div class="alert alert-danger" role="alert">
@@ -155,9 +141,10 @@
                 </div>
                 <% end %>
                 <div class="form-group row ">
-                    <label for="city_name" class="col-md-2 control-label">Confirmar município de voto*</label>
+                    <label for="city_name" class="col-md-2 control-label">Município *</label>
                     <div class="col-md-10">
                         <%= f.hidden_field :city_id %>
+			<span style="padding-left:0px;">(Município em que foi eleita/o)</span>
                         <input type="text" id="city_name" class="form-control" value= '<%= "#{@candidate.city.name}, #{@candidate.city.state}" if @candidate.city %>'>
                         <span class="loading_msg">Carregando...</span>
                         ** às vezes o menu de cidades demora pra carregar, mas espera um pouquinho que vai!

--- a/app/views/candidates/show.html.erb
+++ b/app/views/candidates/show.html.erb
@@ -26,19 +26,21 @@
 <% end %>
 
 <% content_for :menu_logged do %>
+    <% if session[:user_id] and @current_user.admin? %>
+        <%= link_to "Gerenciar dados de candidatos", candidates_management_path, {class: "dropdown-item"} %>
+        <li>
+            <%= form_for @candidate, method: :delete do %>
+                <button type="submit" class="dropdown-item" onclick="return confirm('Você quer mesmo APAGAR esse registro?\nEssa ação é irreversível!');" >Apagar Registro</button>
+	    <% end %>
+	</li>
+        <li>
+		<%= link_to "Liberar Questionário", candidate_free_path(@candidate.id), {class: "dropdown-item"} %>
+        </li>
+            <div class="dropdown-divider"></div>
+    <% end %>
     <% if session[:candidate_id] %>
         <li><a href="<%= edit_candidate_path(@current_user.id) %>" class="dropdown-item">Perfil no #MeRepresenta</a></li>
     <% elsif session[:user_id] %>
-        <% if @current_user.admin? %>
-            <%= link_to "Gereciar dados de candidatos", candidates_management_path, {class: "dropdown-item"} %>
-            <li>
-                <%= form_for @candidate, method: :delete do %>
-                    <button type="submit" class="dropdown-item">Apagar Registro</button>
-                <% end %>
-            <li>
-            <%= link_to "Liberar Questionário", candidate_free_path(@candidate.id), {class: "dropdown-item"} %>
-            <div class="dropdown-divider"></div>
-        <% end %>
         <li><%= link_to "Perfil", edit_user_path(session[:user_id]), {class: "dropdown-item"} %>
         <li><%= link_to "Refazer questionário", new_answer_path, {class: "dropdown-item"} %>
     <% end %>

--- a/app/views/candidates/show.html.erb
+++ b/app/views/candidates/show.html.erb
@@ -1,11 +1,5 @@
-<% content_for :open_graph do %>
-    <meta name="og:url" content="<%= candidate_url(@candidate) %>">
-    <meta name="og:title" content="Eu já encontrei uma candidatura para vereador/a que te representa! E você?">
-    <meta name="og:description" content="Encontrei o candidato <%= @candidate.nickname %> (<%= @candidate.number %>) do <%= @candidate.party.symbol%> no site do #MeRepresenta! 'Bora lá?"
-<% end %>
-
 <% content_for :head do %>
-    <title>Perfil de Candidato</title>
+    <title>Perfil de Vereador(a)</title>
     <link rel="stylesheet" href="/assets/perfil_candidato.css">
 <% end %>
 
@@ -27,7 +21,7 @@
 
 <% content_for :menu_logged do %>
     <% if session[:user_id] and @current_user.admin? %>
-        <%= link_to "Gerenciar dados de candidatos", candidates_management_path, {class: "dropdown-item"} %>
+        <%= link_to "Gerenciar dados de vereadores", candidates_management_path, {class: "dropdown-item"} %>
         <li>
             <%= form_for @candidate, method: :delete do %>
                 <button type="submit" class="dropdown-item" onclick="return confirm('Você quer mesmo APAGAR esse registro?\nEssa ação é irreversível!');" >Apagar Registro</button>
@@ -53,85 +47,32 @@
 <div class="container">
     <div class="flex">
         <div class="info-basica">        
-            <img class="can-pic" src="<%= @candidate.picture %>?type=large" alt="Foto do/a candidato/a">
+            <img class="can-pic" src="<%= @candidate.picture %>?type=large" alt="Foto da/o vereador(a)">
             <span class="info-text name">
                 <%= @candidate.nickname %>
-            </span>
-            <span class="info-text number">
-                nº <span class="candidate-number"><%= @candidate.number %></span>
             </span>
             <span class="info-text party">
                 Partido: <%= @candidate.party.symbol %>
             </span>
-            <% if @candidate.party_union and @candidate.party_union.parties.count > 1 %>
-            <span class="info-text coligacao">
-                Coligação: <%= @candidate.party_union.name %>
-            </span>
-            <span class="info-text score">
-                Nota da Coligação: <%= (@candidate.party_union.score * 10.0).round 2 %>
-            </span>
-            <% else %><br>
             <span class="info-text score">
                 Nota do Partido: <%= (@candidate.party.score * 10.0).round 2 %>
             </span>
-            <% end %>
             <span class="info-text city">
                 Cidade: <%= "#{@candidate.city.name}, #{@candidate.city.state}" %>
-            </span>
-            <span class="votes-int">
-                <%= User.where("users.candidate_id = #{@candidate.id}" ).count %> #MeRepresenta
             </span>
         </div>
         <div class="info-bio">
             <div class="bio">
-                <h3>Sobre o/a candidato/a</h3>
+                <h3>Sobre a/o vereador(a)</h3>
                 <textarea readonly rows="11" cols="40">
                     <%= @candidate.bio %>
                 </textarea>
             </div>
-            <% if ! session[:candidate_id] and  session[:user_id] %>
-                <% if @candidate.id != @current_user.candidate_id %>
-                    <%= form_for @current_user do |f| %>
-                        <%= f.hidden_field :candidate_id, value: @candidate.id %>
-                        <input type="hidden" name="redirect_to" value="<%= candidate_path(@candidate.id)%>">
-                        <button type="submit" id="votar" class="btn btn-amarelo-roxo">
-                            Quero escolher essa candidatura
-                        </button>
-                    <% end %>
-                <% end %>
-            <% end %>
-            
         </div>
     </div>
        
-    <div class="puxar">
-        <div class="title">
-            <h3>Atenção às coligações!</h3>
-            <h5>Os votos nesse/a candidato/a vão para todos os partidos de sua coligação e podem acabar elegendo alguém em quem você não votaria. Veja como avaliamos cada partido dessa coligação em relação às pautas dos direitos humanos e exemplos de quem pode se beneficiar dos votos que essa candidatura receber.</h5>
-        </div>
-
-        <table class="brother">
-            <tbody>
-                <% @candidate.gang.each do |brother| %>
-                <tr>
-                    <td class="candidato">
-                        <%= brother.nickname %>                            
-                    </td>
-                    <td class="partido">
-                        <span class="partido"><%= brother.party.symbol %></span>
-                        <a href="<%= criteria_path %>">
-                            <span class="nota">nota do partido = <%= (10 * brother.party.score).round %></span>
-                        </a>
-                    </td>
-                </tr>
-                <% end %>
-            </tbody>
-        </table>
-    </div>
-
     <div class="respostas">
-        <h2>Veja o que o/a candidato/a respondeu</h2>
-
+        <h2>Veja o que a/o vereador(a) respondeu</h2>
         <table>
             <tbody>
                 <% @candidate.answers.sort{|a, b| a.question_id - b.question.id}.each do |answer| %>
@@ -157,34 +98,6 @@
             </tbody>
         </table>
     </div>
-
-    <% if ( not session[:candidate_id] ) and session[:user_id]%>
-    <div class="nav">   
-        <a href="<%= user_matchup_path(@current_user) %>" class="btn btn-roxo-amarelo" id="btn-voltar"><span>Voltar aos candidatos</span></a>
-        <a href="https://www.facebook.com/dialog/share?app_id=<%= URI.encode ENV['FB_ID'] %>&display=page&href=<%= URI.encode candidate_url(@candidate) %>&redirect_uri=<%= URI.encode candidate_url(@candidate) %>" class="btn btn-roxo-amarelo" id="btn-compartilhar"><span>Compartilhe no facebook!</span></a>
-    </div>
-    <% end %>
 </div>
 
-<% end %>
-
-<% content_for :scripts do %>
-    <div class="share-it invisivel">
-        <h4>Ei, psiu !!! <a href="#">fechar</a></h4>
-        <p>Essa plataforma te representa?</p>
-        <p>Compartilhe no seu facebook e ajude outras pessoas a encontrarem candidaturas pró-direitos humanos no Brasil :)</p>
-        <a href="https://www.facebook.com/dialog/share?app_id=<%= URI.encode ENV['FB_ID'] %>&display=page&href=<%= URI.encode root_url %>&redirect_uri=<%= URI.encode candidate_url(@candidate) %>" class="btn-compartilhe btn btn-amarelo-roxo">Compartilhar com amigos</a>
-    </div>
-    <!-- Este script faz aparecer o botão de "Psiu, compartilhe" depois de 20 segundos
-         Removido temporariamente (2017)
-        script type="text/javascript">
-        (function() {
-            window.setTimeout(function(){
-                $(".share-it").removeClass("invisivel");
-            }, 20000);
-            $(".share-it>h4>a").on("click", function(){
-                $(".share-it").addClass("invisivel");
-            })
-        })();
-    </script-->
 <% end %>


### PR DESCRIPTION
Adequando a apresentação para a plataforma de vereadores. Fiz esse PR baseado no fix_admin para facilitar a incorporação.

- Troquei as ocorrências de "candidato" para "vereador(a)". 
- Retirei do questionário e da página "candidates/show" a informação de número de candidatura e troquei "nome urna" por "apelido", para evitar problemas legais relacionados ao uso de informação eleitoral fora de época
- Removi a informação de coligação do candidates/show pelo mesmo motivo
- Removi os botões de "compartilhe no facebook", "escolha essa candidatura", "25 #MeRepresentas", pois não são relevantes no presente momento